### PR TITLE
Bump dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :url "https://github.com/weavejester/duct-ragtime-component"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.stuartsierra/component "0.3.1"]
-                 [ragtime "0.6.0"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [ragtime "0.7.2"]]
   :profiles
-  {:dev {:dependencies [[com.h2database/h2 "1.4.191"]
-                        [org.clojure/java.jdbc "0.6.1"]]}})
+  {:dev {:dependencies [[com.h2database/h2 "1.4.196"]
+                        [org.clojure/java.jdbc "0.7.3"]]}})

--- a/src/duct/component/ragtime.clj
+++ b/src/duct/component/ragtime.clj
@@ -3,7 +3,7 @@
   (:require [com.stuartsierra.component :as component]
             [ragtime.core :as core]
             [ragtime.jdbc :as jdbc]
-            [ragtime.repl :as repl]
+            [ragtime.reporter :as reporter]
             [ragtime.strategy :as strategy]))
 
 (defn reload
@@ -22,7 +22,7 @@
 
 (def default-options
   {:strategy strategy/raise-error
-   :reporter repl/default-reporter})
+   :reporter reporter/print})
 
 (defn ragtime
   "Create a Ragtime component for handling migrations. Expects a dependency :db
@@ -34,7 +34,7 @@
     :strategy      - the Ragtime strategy
                      (defaults to ragtime.strategy/raise-error)
     :reporter      - the reporter function
-                     (defaults to ragtime.repl/default-reporter)"
+                     (defaults to ragtime.reporter/print)"
   [options]
   {:pre [(contains? options :resource-path)]}
   (map->Ragtime (merge default-options options)))
@@ -42,8 +42,8 @@
 (defn migrate
   "Migrates the dependent database to the latest migration."
   [{:keys [datastore migrations strategy reporter]}]
-  (let [migrations (map #(repl/wrap-reporting % reporter) migrations)]
-    (core/migrate-all datastore {} migrations strategy)))
+  (core/migrate-all datastore {} migrations {:strategy strategy
+                                             :reporter reporter}))
 
 (defn rollback
   "Rolls the dependent database back to a specific migration ID, or by a fixed
@@ -52,8 +52,7 @@
   ([component]
    (rollback component 1))
   ([{:keys [datastore migrations reporter]} amount-or-id]
-   (let [migrations (map #(repl/wrap-reporting % reporter) migrations)
-         index      (core/into-index migrations)]
+   (let [index      (core/into-index migrations)]
      (if (integer? amount-or-id)
-       (core/rollback-last datastore index amount-or-id)
-       (core/rollback-to datastore index amount-or-id)))))
+       (core/rollback-last datastore index amount-or-id {:reporter reporter})
+       (core/rollback-to datastore index amount-or-id {:reporter reporter})))))


### PR DESCRIPTION
This pull request updates the dependencies for this component. The only notable change is the change from `ragtime.repl` to `ragtime.reporter`: Instead of mapping the reporter function over the migrations, we instead pass it in as an option to the migrate and rollback functions.